### PR TITLE
Fix the finetune directory link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The TinyLlama project aims to **pretrain** a **1.1B Llama model on 3 trillion to
 We adopted exactly the same architecture and tokenizer as Llama 2. This means TinyLlama can be plugged and played in many open-source projects built upon Llama. Besides, TinyLlama is compact with only 1.1B parameters. This compactness allows it to cater to a multitude of applications demanding a restricted computation and memory footprint.
 
 #### News
-- 2023-09-16: 1. We released the intermediate checkpoint trained on 503B tokens. 2. We released a chat model finetuned on OpenAssisant and simple finetuning scripts is added [finetune](finetune). 3. We added a [chat demo](https://huggingface.co/spaces/PY007/TinyLlama-1.1B-Chat-Demo) so that you can play with TinyLlama-Chat-V0.1 right away. 4. More eval benchmarks are added and documented in [EVAL.md](EVAL.md). 
+- 2023-09-16: 1. We released the intermediate checkpoint trained on 503B tokens. 2. We released a chat model finetuned on OpenAssisant and simple finetuning scripts is added [finetune]([finetune](https://github.com/jzhang38/TinyLlama/blob/main/sft/)). 3. We added a [chat demo](https://huggingface.co/spaces/PY007/TinyLlama-1.1B-Chat-Demo) so that you can play with TinyLlama-Chat-V0.1 right away. 4. More eval benchmarks are added and documented in [EVAL.md](EVAL.md). 
 
 #### Evaluation
 You can find the evaluation results of TinyLlama in [EVAL.md](EVAL.md).


### PR DESCRIPTION
The link to finetune at the top of the readme points at blob/finetune, fixed to the sft directory